### PR TITLE
Add configuration file support for the NATS server

### DIFF
--- a/charts/nats-server/templates/NOTES.txt
+++ b/charts/nats-server/templates/NOTES.txt
@@ -6,10 +6,7 @@ Monitoring: "nats://{{ .Values.service.name }}:{{ .Values.service.monitorPort }}
 WARNING:  No username/password specified.   
 {{- else }}
 Client:     "nats://{{ .Values.username }}:<your password>@{{ .Values.service.name }}:{{ .Values.service.clientPort }}"
-Monitoring: "nats://{{ .Values.service.name }}:{{ .Values.service.monitorPort }}"
-  {{- if contains "password" .Values.password }}
-WARNING:  You are using the default password.  It is HIGHLY recommended you change this.  
-  {{- end }}   
+Monitoring: "nats://{{ .Values.service.name }}:{{ .Values.service.monitorPort }}" 
 {{- end}}
 
 Ideally you should bcrypt your password using the NATS mkpasswd tool here:

--- a/charts/nats-server/templates/configmap.yaml
+++ b/charts/nats-server/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.overrideImageConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.service.name }}-config
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "nats-server.name" . }}
+data:
+{{- range $key, $val := .Values.configurationFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}

--- a/charts/nats-server/templates/deployment.yaml
+++ b/charts/nats-server/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
 {{- if .Values.trace }}
                  "-V",
 {{- end}}
+{{- if .Values.overrideImageConfig }}
+                 "--config", "/config/gnatsd.conf",
+{{- end}}
                  "--cluster", "nats://0.0.0.0:{{ .Values.service.clusterPort }}",
                  "--routes", "nats://{{ .Values.service.name }}:{{ .Values.service.clusterPort }}"]
           ports:
@@ -46,10 +49,21 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.monitorPort }}           
+              port: {{ .Values.service.monitorPort }}
+{{- if .Values.overrideImageConfig }}
+          volumeMounts:
+          - name: {{ .Values.service.name }}-volume
+            mountPath: /config
+{{- end}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.nodeSelector }}
+    {{- if .Values.nodeSelector }}   
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+{{- if .Values.overrideImageConfig }}
+      volumes:
+      - name: {{ .Values.service.name }}-volume
+        configMap:
+          name:  {{ .Values.service.name }}-config
+{{- end}}     

--- a/charts/nats-server/values.yaml
+++ b/charts/nats-server/values.yaml
@@ -47,7 +47,7 @@ resources: {}
 #
 # The default image configuration can be overridden here, 
 # to override default values.
-overrideImageConfig: true
+overrideImageConfig: false
 
 #
 # Configuration used when the default image is overridden.  It is highly suggested

--- a/charts/nats-server/values.yaml
+++ b/charts/nats-server/values.yaml
@@ -8,10 +8,10 @@ image:
   pullPolicy: IfNotPresent
 
 # User required for connections
-username: "username"
+username: ""
 
 # Password required for connections
-password: "password"
+password: ""
 
 # Debug output.  Will negatively impact performance.
 debug: false
@@ -43,3 +43,58 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+#
+# The default image configuration can be overridden here, 
+# to override default values.
+overrideImageConfig: true
+
+#
+# Configuration used when the default image is overridden.  It is highly suggested
+# to avoid to setting ports, interfaces, or routes here.
+#
+configurationFiles:
+  gnatsd.conf: |- 
+
+    ##  For a full reference, 
+    ##  See:  https://nats.io/documentation/server/gnatsd-config
+    ##
+
+    ##
+    ## You can include configuration files on other PVCs, for example shared.
+    ## authorization files.
+
+    # include "/mypvc/users.conf"
+    
+    ### override limits
+    # max_payload = 10240k 
+    # max_connections = 10
+    # write_deadline = 5s
+
+    # set your authorization scheme for connections and routes here.
+    authorization {
+      # override the default authorization timeout, setup lists of users, etc.
+      timeout: 3
+    }
+
+    # This is for clustering multiple servers together.
+    cluster {
+
+      # Routes are protected, so need to use them with --routes flag
+      # e.g. --routes=nats-route://ruser:T0pS3cr3t@otherdockerhost:6222
+      authorization {
+        # user: ruser
+        # password: T0pS3cr3t
+        timeout: 3.0
+      }
+
+      # reference route certificates as secrets.
+      # tls {
+      #   cert_file:  "/secretsvolume/server.pem"
+      #   key_file:   "/secretsvolume/key.pem"
+      #   timeout:    2
+      # }
+    }
+
+
+


### PR DESCRIPTION
If flagged to override the default docker config file:
* Import an embedded configuration into a configMap, create and mount a volume, etc.
* Pass the configuration in to the NATS server
* Allow referencing external configuration files from configMap to share users